### PR TITLE
Add `Soda::Worker` spec

### DIFF
--- a/lib/soda/worker.rb
+++ b/lib/soda/worker.rb
@@ -28,6 +28,7 @@ module Soda
           )
         end
       end
+      alias_method :perform_at, :perform_in
 
       private
 

--- a/spec/lib/soda/worker_spec.rb
+++ b/spec/lib/soda/worker_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+class StubSodaWorker
+  include Soda::Worker
+
+  soda_options queue: "foo", foo: "bar"
+end
+
+describe Soda::Worker do
+  describe "set" do
+    it "merges over class-level options" do
+      expect_any_instance_of(Soda::Client).to receive(:push).
+        with(hash_including(queue: "bar", foo: "bar"))
+
+      StubSodaWorker.set(queue: "bar").
+        set(queue: "foo").
+        set(queue: "bar").
+        perform_async
+    end
+  end
+
+  describe "#perform_async" do
+    it "pushes to client with no delay" do
+      expect_any_instance_of(Soda::Client).to receive(:push).
+        with(hash_including(queue: "foo", foo: "bar", "delay" => 0))
+
+      StubSodaWorker.perform_async
+    end
+  end
+
+  describe "#perform_in" do
+    it "pushes to client with delay" do
+      expect_any_instance_of(Soda::Client).to receive(:push).
+        with(hash_including(queue: "foo", foo: "bar", "delay" => 10))
+
+      StubSodaWorker.perform_in(10)
+    end
+  end
+end


### PR DESCRIPTION
To improve this file's test coverage. Also added an alias to
`Soda::Worker::Options`.